### PR TITLE
Fix #8; Update Code of Conduct and other content

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -20,5 +20,9 @@ a:hover {
 	font-weight: normal;
 	text-decoration: underline;
 }
+h1 a:hover {
+	font-weight: bold;
+	text-decoration: none;
+}
 
 section ul li { margin-bottom: 10px; }

--- a/contributors/index.md
+++ b/contributors/index.md
@@ -5,13 +5,17 @@ layout: default
 
 ## Contributors
 
-Contributors are currently are students in both the Computer and Systems Science programs but all are welcome.  Before contributing please refer to the [Code of Conduct](code-of-conduct.md) and the following articles:
+Contributors are currently are students in both the Computer and Systems Science programs but all are welcome.  Before contributing please refer to the following articles:
 
 * [Work with Github Issues and Pull Requests](http://docs.geonode.org/en/master/organizational/contribute/work_with_github.html){:target="_blank"}
 * [How to Write a Commit Message](https://chris.beams.io/posts/git-commit/){:target="_blank"}
 
 These will be especially useful if you are new to git and Github collaboration, otherwise they should be a review of Best Practices the Project strives toward.
 
-The project repository is at [https://github.com/occam-ra/occam](https://github.com/occam-ra/occam) and should include increasingly more technical documentation.
+In addition, while we're working on adopting a formal Code of Conduct, please do your best to give others the benefit of the doubt and adhere to the Inverse Golden Rule: *Do not unto others that which you would not have done unto yourself*.
+
+The project repository can be found at [https://github.com/occam-ra/occam](https://github.com/occam-ra/occam) and should include increasingly more technical documentation.
 
 Take a look at [the good first issues](https://github.com/occam-ra/occam/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22){:target="_blank"} to jump right in.
+
+The repository for this website can be found at [https://github.com/occam-ra/occam](https://github.com/occam-ra/occam), any Issues and Pull Requests on usability, accessibility, content proofing, etc. are also appreciated.

--- a/index.md
+++ b/index.md
@@ -6,12 +6,12 @@ layout: default
 ## OCCAM: Reconstructability Analysis Tools
 **O**rganizational **C**omplexity **C**omputation **a**nd **M**odeling.
 
-![Diagram of 4 Variable Reconstructability Analysis](img/reconstructability-analysis.png){:class="ra-img"} OCCAM combines machine learning, data mining, and statistical analysis in a powerful workflow that can be applied to nearly any type of data to understand its structure, select among possible models, and make predictions. It is a collection of software tools comprising a library with both command-line and web interfaces for *Reconstructability Analysis* (RA), an information-theoretic form of statistical analysis closely related to [Factor Analysis](https://en.wikipedia.org/wiki/Factor_analysis){:target="_blank"} and [Bayesian Networks](https://en.wikipedia.org/wiki/Bayesian_network){:target="_blank"}.
+![Diagram of 4 Variable Reconstructability Analysis](img/reconstructability-analysis.png){:class="ra-img"} OCCAM combines machine learning, data mining, and statistical analysis in a powerful workflow that can be applied to to both categorical and quantitative data to understand its structure, select among possible models, and make predictions or discover variable associations. It is a collection of software tools comprising a library with both command-line and web interfaces for *Reconstructability Analysis* (RA), an information-theoretic form of statistical analysis closely related to [Bayesian Networks](https://en.wikipedia.org/wiki/Bayesian_network){:target="_blank"} and [log-linear modeling](https://en.wikipedia.org/wiki/Log-linear_model){:target="_blank"}.
 
 
 The OCCAM project has been developed over several decades at Portland State University under the auspices of its creator Prof. Martin Zwick. Programmers contributing to the work have included Ken Willett, Joe Fusion and H. Forrest Alexander. It its current form it is proprietary, but the primary focus of development efforts at this time is to make OCCAM open source, and to repackage it to provide easy access for researchers, data scientists, and developers who wish to access the functionality in a standard way.
 
-The [current working version of OCCAM](https://dmm.sysc.pdx.edu) is maintained at PSU. That site contains some introductory and research material.
+The [current working version of OCCAM](http://dmm.sysc.pdx.edu/weboccam.cgi) is maintained at PSU. That site contains some introductory and research material.
 
 For a fuller introduction, see the following papers by Dr. Zwick:
 * [Wholes and Parts in General Systems Methodology](https://www.pdx.edu/sites/www.pdx.edu.sysc/files/sysc_wholesg.pdf){:target="_blank"}


### PR DESCRIPTION
While we deliberate over the exact Code of Conduct to adopt for the project, the link to the first proposed CoC was removed and replaced by an informal "code" and notice of intentions to adopt a formal Code.

Additionally, index page content and OCCAM link was updated per Marty's suggestions.